### PR TITLE
Fastly OSS standards

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020, Fastly, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# homebrew-tap
-Homebrew Formulae to waflyctl binaries
+# Homebrew tap
+Homebrew tap repository that provides formula for public Fastly binaries, such as the [Fastly CLI](https://github.com/fastly/cli) or [waflyctl](https://github.com/fastly/waflyctl).
+
+**Note:** the formulae content of this repository is automatically generated.
+
+## Install
+To tap the repository and thus make all formula available to subsequent `brew` commands:
+```
+brew tap fastly/tap
+```
+
+To install individual formula:
+
+### Fastly CLI
+```
+brew install fastly/tap/fastly
+```
+
+### waflyctl
+```
+brew install fastly/tap/waflyctl
+```
+
+## Issues
+If you encounter any non-security-related bug or unexpected behavior, please file an issue on the corresponding project repository (i.e. [CLI](https://github.com/fastly/cli/issues) or [waflyctl](https://github.com/fastly/waflyctl/issues)), not this one.
+
+### Security issues
+Please see our [SECURITY.md](SECURITY.md) for guidance on reporting security-related issues.
+
+## License
+[MIT](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+## Report a security issue
+
+The fastly/homebrew-tap project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via [Fastly’s security issue reporting process](https://www.fastly.com/security/report-security-issue).
+
+## Security advisories
+
+Remediation of security vulnerabilities is prioritized by the project team. The project team endeavors to coordinate remediation with third-party stakeholders, and is committed to transparency in the disclosure process. The fastly/homebrew-tap team announces security issues in release notes as well as Github Security Advisories on a best-effort basis.
+
+Note that communications related to security issues in Fastly-maintained OSS as described here are distinct from [Fastly Security Advisories](https://www.fastly.com/security-advisories).


### PR DESCRIPTION
Cleans up the repository to align with Fastly's open-source software standards. 
Specifically:

- Adds a [LICENSE](https://github.com/fastly/homebrew-tap/compare/phamann/clean-up?expand=1#diff-9879d6db96fd29134fc802214163b95a)
- Adds a [`SECURITY.md`](https://github.com/fastly/homebrew-tap/compare/phamann/clean-up?expand=1#diff-f1a97ccd40c28e5c0945852559d3903c)
- Adds issues, security issues and license sections to the [README.md](https://github.com/fastly/homebrew-tap/compare/phamann/clean-up?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8)